### PR TITLE
fedora: Fix linking against wrong libgc

### DIFF
--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -30,7 +30,8 @@ RUN curl --retry 5 -sL https://github.com/crystal-lang/crystal/archive/refs/tags
   tar -zxf- --strip-components=1 && \
   gzip -9 man/crystal.1 && \
   mkdir .build && \
-  make crystal interpreter=1 release=1 target=$TARGETARCH-unknown-linux-gnu PREFIX=/usr FLAGS="--no-debug" | tail -1 > .build/crystal.sh && \
+  make crystal interpreter=1 release=1 target=$TARGETARCH-unknown-linux-gnu \
+    PREFIX=/usr FLAGS="--no-debug" CRYSTAL_CONFIG_LIBRARY_PATH=/usr/lib64/crystal | tail -1 > .build/crystal.sh && \
   rm src/llvm/ext/llvm_ext.o
 # Build shards
 WORKDIR /tmp/shards
@@ -84,7 +85,7 @@ COPY --from=builder /tmp/shards/man/shard.yml.5.gz pkg/usr/share/man/man5/
 COPY --from=builder /tmp/crystal/src pkg/usr/share/crystal/src
 COPY --from=target-builder /tmp/crystal/.build/crystal pkg/usr/bin/
 COPY --from=target-builder /tmp/shards/bin/shards pkg/usr/bin/
-COPY --from=target-builder /usr/lib64/libgc.a pkg/usr/lib64/
+COPY --from=target-builder /usr/lib64/libgc.a pkg/usr/lib64/crystal/
 ARG crystal_version
 ARG llvm_version
 ARG pkg_revision=1


### PR DESCRIPTION
When building a non-static binary, this would always end up choosing /usr/lib64/libgc.so.1 over /usr/lib64/libgc.a. Arguably, a library specifically part of Crystal shouldn't be in /usr/lib64 anyway, so move it to the standard subdirectory & point Crystal there to find it.

### WHY are these changes introduced?

(see above commit message)

### WHAT is this pull request doing?

(see above commit message)

### HOW can this pull request be tested?

Try building something with `-Dpreview_mt`.

---

Friendly reminders

- Include reference to Trello (or possibly Slack)
- Include changelog to support if applicable
- Lint rules pass
- The environment (`heroku config`) has been updated if needed (new `ENV` variables)
