### PR TITLE
Add debian:12 to CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
             llvm_version: 10
           - base_image: debian
             version: 12
-            codename: bullseye
+            codename: bookworm
             llvm_version: 15
           - base_image: debian
             version: 11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,10 @@ jobs:
             codename: bionic
             llvm_version: 10
           - base_image: debian
+            version: 12
+            codename: bullseye
+            llvm_version: 15
+          - base_image: debian
             version: 11
             codename: bullseye
             llvm_version: 13

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -95,7 +95,7 @@ jobs:
             llvm_version: 10
           - base_image: debian
             version: 12
-            codename: bullseye
+            codename: bookworm
             llvm_version: 15
           - base_image: debian
             version: 11

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -94,6 +94,10 @@ jobs:
             codename: bionic
             llvm_version: 10
           - base_image: debian
+            version: 12
+            codename: bullseye
+            llvm_version: 15
+          - base_image: debian
             version: 11
             codename: bullseye
             llvm_version: 13


### PR DESCRIPTION
### WHY are these changes introduced?

Add support for debian-12 as an underlying image.

### WHAT is this pull request doing?

Adding CI build for debian 12 on LLVM 15.

### HOW can this pull request be tested?

CI build succeeds.