### PR TITLE
Add xz-static to alpine image

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -55,7 +55,7 @@ RUN sh -ex bin/shards.sh && strip bin/shards
 # start from a clean image
 FROM alpine:$alpine_version
 # add dependencies commonly required for building crystal applications
-RUN apk add --update --no-cache musl-dev gcc pcre2-dev libevent-dev libevent-static openssl-dev openssl-libs-static libxml2-dev zlib-dev zlib-static git make yaml-dev libxml2-static gmp-dev
+RUN apk add --update --no-cache musl-dev gcc pcre2-dev libevent-dev libevent-static openssl-dev openssl-libs-static libxml2-dev zlib-dev zlib-static git make yaml-dev libxml2-static gmp-dev xz-static
 # copy the binaries + stdlib + libgc from the build stage
 COPY --from=builder /usr/src/crystal/*.md /usr/share/doc/crystal/
 COPY --from=builder /usr/src/crystal/man/crystal.1.gz /usr/share/man/man1/


### PR DESCRIPTION
### WHY are these changes introduced?

* Enable building static binaries that use e.g. libxml2

### WHAT is this pull request doing?

* Add xz-static package to Alpine image

### HOW can this pull request be tested?

* Run a container with the alpine image
* `apk list xz-static` to check if installed
