### PR TITLE
build all images every day to get the latest libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
     paths-ignore:
       - README.md
       - .github/workflows/master.yml
+  schedule:
+    - cron: '45 4 * * *'
 
 env:
   crystal_version: 1.13.3


### PR DESCRIPTION
### WHY are these changes introduced?

Version incompabilities between library versions in the build image and the runtime image can otherwise cause segfaults and other problems.

See: https://github.com/cloudamqp/amqproxy/issues/178

### WHAT is this pull request doing?

Building a images every day at 4:45am UTC.

### HOW can this pull request be tested?

