### PR TITLE
Bump actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
             pkg_revision=${{ github.run_number }}
           outputs: pkgs
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: crystal-static-pkgs
           path: pkgs
@@ -165,7 +165,7 @@ jobs:
           target: pkgs
           outputs: pkgs
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: crystal-${{ matrix.base_image }}-${{ matrix.version }}-pkgs
           path: pkgs
@@ -241,7 +241,7 @@ jobs:
           target: pkgs
           outputs: pkgs
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: crystal-${{ matrix.base_image }}-${{ matrix.version }}-pkgs
           path: pkgs
@@ -312,7 +312,7 @@ jobs:
           target: pkgs
           outputs: pkgs
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: crystal-${{ matrix.base_image }}-${{ matrix.base_image_tag }}-pkgs
           path: pkgs
@@ -381,7 +381,7 @@ jobs:
           target: pkgs
           outputs: pkgs
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: crystal-centos-${{ matrix.base_image_tag }}-pkgs
           path: pkgs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             llvm_version: 18
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -63,7 +63,7 @@ jobs:
     needs: alpine
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: depot/setup-action@v1
       - uses: depot/build-push-action@v1
         with:
@@ -115,7 +115,7 @@ jobs:
             llvm_version: 13
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -191,7 +191,7 @@ jobs:
             llvm_version: 12
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -268,7 +268,7 @@ jobs:
             base_image_tag: 40
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -335,7 +335,7 @@ jobs:
             el_version: 9
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -25,7 +25,7 @@ jobs:
             llvm_version: 16
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -56,7 +56,7 @@ jobs:
     needs: alpine
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: depot/setup-action@v1
       - uses: depot/build-push-action@v1
         with:
@@ -91,7 +91,7 @@ jobs:
             llvm_version: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -155,7 +155,7 @@ jobs:
             base_image_tag: 40
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -69,7 +69,7 @@ jobs:
             pkg_revision=${{ github.run_number }}
           outputs: pkgs
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: crystal-static-pkgs
           path: pkgs
@@ -139,7 +139,7 @@ jobs:
           target: pkgs
           outputs: pkgs
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: crystal-${{ matrix.base_image }}-${{ matrix.version }}-pkgs
           path: pkgs
@@ -198,7 +198,7 @@ jobs:
           target: pkgs
           outputs: pkgs
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: crystal-${{ matrix.base_image }}-${{ matrix.base_image_tag }}-pkgs
           path: pkgs


### PR DESCRIPTION
### WHY are these changes introduced?

`actions/upload-artifact action@v3` is [deprecated](https://github.com/actions/upload-artifact/blob/v4.4.3/README.md#actionsupload-artifact):

> actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) Similarly, v1/v2 are scheduled for deprecation on June 30, 2024. Please update your workflow to use v4 of the artifact actions. This deprecation will not impact any existing versions of GitHub Enterprise Server being used by customers.

`actions/checkout@v3` uses old node version, causing warnings to be emitted

### WHAT is this pull request doing?

Bumping `actions/checkout` and `actions/upload-artifact` actions.

### HOW can this pull request be tested?

If CI passes, it's hopefully fine.