### PR TITLE
Change `llvm` dependency to `libllvm` for DEB

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -90,7 +90,7 @@ RUN fpm -s dir -t deb -n crystal -v $(cat pkg/usr/share/crystal/src/VERSION) --i
   --description "a general-purpose, object-oriented programming language" \
   --depends gcc --depends pkg-config --depends libevent-dev \
   --depends libpcre2-dev \
-  --depends llvm-$llvm_version --depends libz-dev --depends libffi-dev \
+  --depends libllvm$llvm_version --depends libz-dev --depends libffi-dev \
   --deb-recommends libssl-dev --deb-recommends libxml2-dev \
   --deb-recommends libgmp-dev --deb-recommends libyaml-dev \
   --deb-recommends git \


### PR DESCRIPTION
The compiler does not need the full `llvm` package. Just the runtime library `libllvm` should be enough for typical use cases. This reduces the installation size significantly: in Debian bookworm `libllvm15` installs 180 MB, while `llvm-15` installs 882 MB. Without recommends it's still 261 MB.

The full `llvm` package would only be required for building Crystal programs that link against `libllvm`, such as the compiler. So it could be cons

This change aligns with the RPM packages which depend on `llvm-libs`, and the Alpine docker image which has `libllvm` statically linked and `llvm` is not installed.

